### PR TITLE
CT-848: Add merchant ID and plugin version to Connector script URL.

### DIFF
--- a/inc/classes/class-frontend-post.php
+++ b/inc/classes/class-frontend-post.php
@@ -246,6 +246,17 @@ class Frontend_Post {
 		// @todo make sure to select eu based on locale, once upstream LaterPay starts supporting them.
 		$connector_url = $region_connector_urls['us'];
 
+		// Append merchant ID and plugin version to Connector script URL.
+		$credentials = Client_Account::get_merchant_credentials();
+		$merchant_id = ( ! empty( $credentials ) ) ? $credentials['merchant_id'] : '';
+
+		$connector_url = add_query_arg(
+			[
+				'wp'     => $merchant_id,
+				'revgen' => REVENUE_GENERATOR_VERSION,
+			],
+			$connector_url
+		);
 
 		// Enqueue connector script based on region and environment.
 		// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.NoExplicitVersion -- Upstream script.


### PR DESCRIPTION
This PR addresses [CT-848](https://laterpay.atlassian.net/browse/CT-848).

- It adds `wp` and `revgen` URL parameters to Connector script called from frontend.

- `wp` parameter contains merchant ID.

- `revgen` is the version of Revenue Generator plugin making the call.

This allows tracking of which merchants use Connector integration and what version of Rev Gen they're running. It will become useful for us in the near future as it will let us know which merchants have not migrated to 2.0 yet.