### PR TITLE
CT-980: Add filters to allow toggling plugin features.

### DIFF
--- a/inc/classes/class-admin.php
+++ b/inc/classes/class-admin.php
@@ -916,7 +916,7 @@ class Admin {
 		$is_paywall_setup_done = empty( $current_global_options['average_post_publish_count'] ) ? false : true;
 
 		if ( $is_paywall_setup_done || ( ! empty( $is_welcome_setup_done ) && 'contribution' === $is_welcome_setup_done ) ) {
-			if ( apply_filters( 'rg_paywalls_enabled', true ) ) {
+			if ( apply_filters( 'rg_paywalls_enabled', REVENUE_GENERATOR_HAS_PAYWALLS ) ) {
 				$menus['dashboard'] = [
 					'url'    => 'revenue-generator-dashboard',
 					'title'  => __( 'Paywall', 'revenue-generator' ),
@@ -925,7 +925,7 @@ class Admin {
 				];
 			}
 
-			if ( apply_filters( 'rg_contributions_enabled', true ) ) {
+			if ( apply_filters( 'rg_contributions_enabled', REVENUE_GENERATOR_HAS_CONTRIBUTIONS ) ) {
 				$menus['contributions'] = [
 					'url'    => Contribution::ADMIN_DASHBOARD_SLUG,
 					'title'  => __( 'Contributions', 'revenue-generator' ),
@@ -941,7 +941,7 @@ class Admin {
 				];
 			}
 
-			if ( apply_filters( 'rg_paywalls_enabled', true ) ) {
+			if ( apply_filters( 'rg_paywalls_enabled', REVENUE_GENERATOR_HAS_PAYWALLS ) ) {
 				$menus['paywall'] = [
 					'url'    => 'revenue-generator-paywall',
 					'title'  => __( 'New Paywall', 'revenue-generator' ),

--- a/inc/classes/class-admin.php
+++ b/inc/classes/class-admin.php
@@ -916,33 +916,39 @@ class Admin {
 		$is_paywall_setup_done = empty( $current_global_options['average_post_publish_count'] ) ? false : true;
 
 		if ( $is_paywall_setup_done || ( ! empty( $is_welcome_setup_done ) && 'contribution' === $is_welcome_setup_done ) ) {
-			$menus['dashboard'] = [
-				'url'    => 'revenue-generator-dashboard',
-				'title'  => __( 'Paywall', 'revenue-generator' ),
-				'cap'    => 'manage_options',
-				'method' => 'dashboard',
-			];
+			if ( apply_filters( 'rg_paywalls_enabled', true ) ) {
+				$menus['dashboard'] = [
+					'url'    => 'revenue-generator-dashboard',
+					'title'  => __( 'Paywall', 'revenue-generator' ),
+					'cap'    => 'manage_options',
+					'method' => 'dashboard',
+				];
+			}
 
-			$menus['contributions'] = [
-				'url'    => Contribution::ADMIN_DASHBOARD_SLUG,
-				'title'  => __( 'Contributions', 'revenue-generator' ),
-				'cap'    => 'manage_options',
-				'method' => 'contributions',
-			];
+			if ( apply_filters( 'rg_contributions_enabled', true ) ) {
+				$menus['contributions'] = [
+					'url'    => Contribution::ADMIN_DASHBOARD_SLUG,
+					'title'  => __( 'Contributions', 'revenue-generator' ),
+					'cap'    => 'manage_options',
+					'method' => 'contributions',
+				];
 
-			$menus['contribution'] = [
-				'url'    => Contribution::ADMIN_EDIT_SLUG,
-				'title'  => __( 'Contribution', 'revenue-generator' ),
-				'cap'    => 'manage_options',
-				'method' => 'contribution',
-			];
+				$menus['contribution'] = [
+					'url'    => Contribution::ADMIN_EDIT_SLUG,
+					'title'  => __( 'Contribution', 'revenue-generator' ),
+					'cap'    => 'manage_options',
+					'method' => 'contribution',
+				];
+			}
 
-			$menus['paywall'] = [
-				'url'    => 'revenue-generator-paywall',
-				'title'  => __( 'New Paywall', 'revenue-generator' ),
-				'cap'    => 'manage_options',
-				'method' => 'paywall',
-			];
+			if ( apply_filters( 'rg_paywalls_enabled', true ) ) {
+				$menus['paywall'] = [
+					'url'    => 'revenue-generator-paywall',
+					'title'  => __( 'New Paywall', 'revenue-generator' ),
+					'cap'    => 'manage_options',
+					'method' => 'paywall',
+				];
+			}
 
 			$menus['settings'] = [
 				'url'    => 'revenue-generator-settings',

--- a/inc/classes/class-admin.php
+++ b/inc/classes/class-admin.php
@@ -916,7 +916,7 @@ class Admin {
 		$is_paywall_setup_done = empty( $current_global_options['average_post_publish_count'] ) ? false : true;
 
 		if ( $is_paywall_setup_done || ( ! empty( $is_welcome_setup_done ) && 'contribution' === $is_welcome_setup_done ) ) {
-			if ( apply_filters( 'rg_paywalls_enabled', REVENUE_GENERATOR_HAS_PAYWALLS ) ) {
+			if ( REVENUE_GENERATOR_HAS_PAYWALLS ) {
 				$menus['dashboard'] = [
 					'url'    => 'revenue-generator-dashboard',
 					'title'  => __( 'Paywall', 'revenue-generator' ),
@@ -925,7 +925,7 @@ class Admin {
 				];
 			}
 
-			if ( apply_filters( 'rg_contributions_enabled', REVENUE_GENERATOR_HAS_CONTRIBUTIONS ) ) {
+			if ( REVENUE_GENERATOR_HAS_CONTRIBUTIONS ) {
 				$menus['contributions'] = [
 					'url'    => Contribution::ADMIN_DASHBOARD_SLUG,
 					'title'  => __( 'Contributions', 'revenue-generator' ),
@@ -941,7 +941,7 @@ class Admin {
 				];
 			}
 
-			if ( apply_filters( 'rg_paywalls_enabled', REVENUE_GENERATOR_HAS_PAYWALLS ) ) {
+			if ( REVENUE_GENERATOR_HAS_PAYWALLS ) {
 				$menus['paywall'] = [
 					'url'    => 'revenue-generator-paywall',
 					'title'  => __( 'New Paywall', 'revenue-generator' ),

--- a/inc/classes/class-client-account.php
+++ b/inc/classes/class-client-account.php
@@ -289,8 +289,6 @@ class Client_Account {
 	 * @return string
 	 */
 	private function build_test_fetch_url() {
-		$this->validate_merchant_account();
-
 		// Demo params to verify merchant domain.
 		$fetch_url_params = build_query(
 			[

--- a/inc/classes/class-frontend-post.php
+++ b/inc/classes/class-frontend-post.php
@@ -232,7 +232,7 @@ class Frontend_Post {
 		);
 
 		// Return early if merchant region is empty or when paywalls feature is disabled.
-		if ( empty( $this->merchant_region ) || ! apply_filters( 'rg_paywalls_enabled', REVENUE_GENERATOR_HAS_PAYWALLS ) ) {
+		if ( empty( $this->merchant_region ) || ! REVENUE_GENERATOR_HAS_PAYWALLS ) {
 			return;
 		}
 
@@ -284,7 +284,7 @@ class Frontend_Post {
 		}
 
 		// Return early if paywalls feature is disabled.
-		if ( ! apply_filters( 'rg_paywalls_enabled', REVENUE_GENERATOR_HAS_PAYWALLS ) ) {
+		if ( ! REVENUE_GENERATOR_HAS_PAYWALLS ) {
 			return $post_content;
 		}
 

--- a/inc/classes/class-frontend-post.php
+++ b/inc/classes/class-frontend-post.php
@@ -231,7 +231,7 @@ class Frontend_Post {
 			$assets_instance->get_asset_version( 'css/revenue-generator-frontend.css' )
 		);
 
-		if ( empty( $this->merchant_region ) ) {
+		if ( empty( $this->merchant_region ) || ! apply_filters( 'rg_paywalls_enabled', true ) ) {
 			return;
 		}
 
@@ -279,6 +279,10 @@ class Frontend_Post {
 	public function revenue_generator_post_content( $post_content ) {
 		// Bail early, if unsupported post type.
 		if ( ! is_singular( Post_Types::get_allowed_post_types() ) ) {
+			return $post_content;
+		}
+
+		if ( ! apply_filters( 'rg_paywalls_enabled', true ) ) {
 			return $post_content;
 		}
 

--- a/inc/classes/class-frontend-post.php
+++ b/inc/classes/class-frontend-post.php
@@ -231,6 +231,7 @@ class Frontend_Post {
 			$assets_instance->get_asset_version( 'css/revenue-generator-frontend.css' )
 		);
 
+		// Return early if merchant region is empty or when paywalls feature is disabled.
 		if ( empty( $this->merchant_region ) || ! apply_filters( 'rg_paywalls_enabled', REVENUE_GENERATOR_HAS_PAYWALLS ) ) {
 			return;
 		}
@@ -282,6 +283,7 @@ class Frontend_Post {
 			return $post_content;
 		}
 
+		// Return early if paywalls feature is disabled.
 		if ( ! apply_filters( 'rg_paywalls_enabled', REVENUE_GENERATOR_HAS_PAYWALLS ) ) {
 			return $post_content;
 		}

--- a/inc/classes/class-frontend-post.php
+++ b/inc/classes/class-frontend-post.php
@@ -231,7 +231,7 @@ class Frontend_Post {
 			$assets_instance->get_asset_version( 'css/revenue-generator-frontend.css' )
 		);
 
-		if ( empty( $this->merchant_region ) || ! apply_filters( 'rg_paywalls_enabled', true ) ) {
+		if ( empty( $this->merchant_region ) || ! apply_filters( 'rg_paywalls_enabled', REVENUE_GENERATOR_HAS_PAYWALLS ) ) {
 			return;
 		}
 
@@ -282,7 +282,7 @@ class Frontend_Post {
 			return $post_content;
 		}
 
-		if ( ! apply_filters( 'rg_paywalls_enabled', true ) ) {
+		if ( ! apply_filters( 'rg_paywalls_enabled', REVENUE_GENERATOR_HAS_PAYWALLS ) ) {
 			return $post_content;
 		}
 

--- a/inc/classes/class-plugin.php
+++ b/inc/classes/class-plugin.php
@@ -82,5 +82,7 @@ class Plugin {
 		define( 'REVENUE_GENERATOR_PLUGIN_URL', plugins_url( '', REVENUE_GENERATOR_PLUGIN_FILE ) );
 		define( 'REVENUE_GENERATOR_BUILD_DIR', REVENUE_GENERATOR_PLUGIN_DIR . '/assets/build/' );
 		define( 'REVENUE_GENERATOR_BUILD_URL', plugins_url( '/assets/build/', REVENUE_GENERATOR_PLUGIN_FILE ) );
+		define( 'REVENUE_GENERATOR_HAS_PAYWALLS', true );
+		define( 'REVENUE_GENERATOR_HAS_CONTRIBUTIONS', true );
 	}
 }

--- a/inc/classes/class-plugin.php
+++ b/inc/classes/class-plugin.php
@@ -82,7 +82,7 @@ class Plugin {
 		define( 'REVENUE_GENERATOR_PLUGIN_URL', plugins_url( '', REVENUE_GENERATOR_PLUGIN_FILE ) );
 		define( 'REVENUE_GENERATOR_BUILD_DIR', REVENUE_GENERATOR_PLUGIN_DIR . '/assets/build/' );
 		define( 'REVENUE_GENERATOR_BUILD_URL', plugins_url( '/assets/build/', REVENUE_GENERATOR_PLUGIN_FILE ) );
-		define( 'REVENUE_GENERATOR_HAS_PAYWALLS', true );
-		define( 'REVENUE_GENERATOR_HAS_CONTRIBUTIONS', true );
+		define( 'REVENUE_GENERATOR_HAS_PAYWALLS', apply_filters( 'rg_paywalls_enabled', true ) );
+		define( 'REVENUE_GENERATOR_HAS_CONTRIBUTIONS', apply_filters( 'rg_contributions_enabled', true ) );
 	}
 }

--- a/inc/classes/class-shortcodes.php
+++ b/inc/classes/class-shortcodes.php
@@ -25,16 +25,17 @@ class Shortcodes {
 	 */
 	protected function __construct() {
 		// Setup required hooks.
-		$this->setup_shortcodes();
-
+		add_action( 'init', [ $this, 'setup_shortcodes' ] );
 	}
 
 	/**
 	 * Setup Shortcodes.
 	 */
-	private function setup_shortcodes() {
-		add_shortcode( 'laterpay_contribution', array( $this, 'render_contribution_dialog' ) );
-		add_action( 'wp_enqueue_scripts', array( $this, 'register_shortcode_assets' ) );
+	public function setup_shortcodes() {
+		if ( apply_filters( 'rg_contributions_enabled', true ) ) {
+			add_shortcode( 'laterpay_contribution', array( $this, 'render_contribution_dialog' ) );
+			add_action( 'wp_enqueue_scripts', array( $this, 'register_shortcode_assets' ) );
+		}
 	}
 
 	/**

--- a/inc/classes/class-shortcodes.php
+++ b/inc/classes/class-shortcodes.php
@@ -32,7 +32,7 @@ class Shortcodes {
 	 * Setup Shortcodes.
 	 */
 	public function setup_shortcodes() {
-		if ( apply_filters( 'rg_contributions_enabled', REVENUE_GENERATOR_HAS_CONTRIBUTIONS ) ) {
+		if ( REVENUE_GENERATOR_HAS_CONTRIBUTIONS ) {
 			add_shortcode( 'laterpay_contribution', array( $this, 'render_contribution_dialog' ) );
 			add_action( 'wp_enqueue_scripts', array( $this, 'register_shortcode_assets' ) );
 		}

--- a/inc/classes/class-shortcodes.php
+++ b/inc/classes/class-shortcodes.php
@@ -32,7 +32,7 @@ class Shortcodes {
 	 * Setup Shortcodes.
 	 */
 	public function setup_shortcodes() {
-		if ( apply_filters( 'rg_contributions_enabled', true ) ) {
+		if ( apply_filters( 'rg_contributions_enabled', REVENUE_GENERATOR_HAS_CONTRIBUTIONS ) ) {
 			add_shortcode( 'laterpay_contribution', array( $this, 'render_contribution_dialog' ) );
 			add_action( 'wp_enqueue_scripts', array( $this, 'register_shortcode_assets' ) );
 		}

--- a/templates/backend/welcome/welcome.php
+++ b/templates/backend/welcome/welcome.php
@@ -32,14 +32,19 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<h1 class="rev-gen-welcome__title"><?php esc_html_e( 'Where would you like to start?', 'revenue-generator' ); ?></h1>
 
 			<div class="rev-gen-welcome__buttons-wrap">
+				<?php if ( apply_filters( 'rg_contributions_enabled', true ) ) : ?>
 				<div id="rg_Contribution" class="rev-gen-card">
 					<img class="rev-gen-card__icon" alt="<?php esc_attr_e( 'Create contribution icon', 'revenue-generator' ); ?>" src="<?php echo esc_url( $welcome_contribution_icon ); ?>">
 					<h5 class="rev-gen-card__title"><?php esc_html_e( 'Create Contribution', 'revenue-generator' ); ?></h5>
 				</div>
+				<?php endif; ?>
+
+				<?php if ( apply_filters( 'rg_paywalls_enabled', true ) ) : ?>
 				<div id="rg_Paywall" class="rev-gen-card">
 					<img class="rev-gen-card__icon" alt="<?php esc_attr_e( 'Create Paywall icon', 'revenue-generator' ); ?>" src="<?php echo esc_url( $welcome_paywall_icon ); ?>">
 					<h5 class="rev-gen-card__title"><?php esc_html_e( 'Create Paywall', 'revenue-generator' ); ?></h5>
 				</div>
+				<?php endif; ?>
 			</div>
 		</section>
 	</section>

--- a/templates/backend/welcome/welcome.php
+++ b/templates/backend/welcome/welcome.php
@@ -32,14 +32,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<h1 class="rev-gen-welcome__title"><?php esc_html_e( 'Where would you like to start?', 'revenue-generator' ); ?></h1>
 
 			<div class="rev-gen-welcome__buttons-wrap">
-				<?php if ( apply_filters( 'rg_contributions_enabled', REVENUE_GENERATOR_HAS_CONTRIBUTIONS ) ) : ?>
+				<?php if ( REVENUE_GENERATOR_HAS_CONTRIBUTIONS ) : ?>
 				<div id="rg_Contribution" class="rev-gen-card">
 					<img class="rev-gen-card__icon" alt="<?php esc_attr_e( 'Create contribution icon', 'revenue-generator' ); ?>" src="<?php echo esc_url( $welcome_contribution_icon ); ?>">
 					<h5 class="rev-gen-card__title"><?php esc_html_e( 'Create Contribution', 'revenue-generator' ); ?></h5>
 				</div>
 				<?php endif; ?>
 
-				<?php if ( apply_filters( 'rg_paywalls_enabled', REVENUE_GENERATOR_HAS_PAYWALLS ) ) : ?>
+				<?php if ( REVENUE_GENERATOR_HAS_PAYWALLS ) : ?>
 				<div id="rg_Paywall" class="rev-gen-card">
 					<img class="rev-gen-card__icon" alt="<?php esc_attr_e( 'Create Paywall icon', 'revenue-generator' ); ?>" src="<?php echo esc_url( $welcome_paywall_icon ); ?>">
 					<h5 class="rev-gen-card__title"><?php esc_html_e( 'Create Paywall', 'revenue-generator' ); ?></h5>

--- a/templates/backend/welcome/welcome.php
+++ b/templates/backend/welcome/welcome.php
@@ -32,14 +32,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<h1 class="rev-gen-welcome__title"><?php esc_html_e( 'Where would you like to start?', 'revenue-generator' ); ?></h1>
 
 			<div class="rev-gen-welcome__buttons-wrap">
-				<?php if ( apply_filters( 'rg_contributions_enabled', true ) ) : ?>
+				<?php if ( apply_filters( 'rg_contributions_enabled', REVENUE_GENERATOR_HAS_CONTRIBUTIONS ) ) : ?>
 				<div id="rg_Contribution" class="rev-gen-card">
 					<img class="rev-gen-card__icon" alt="<?php esc_attr_e( 'Create contribution icon', 'revenue-generator' ); ?>" src="<?php echo esc_url( $welcome_contribution_icon ); ?>">
 					<h5 class="rev-gen-card__title"><?php esc_html_e( 'Create Contribution', 'revenue-generator' ); ?></h5>
 				</div>
 				<?php endif; ?>
 
-				<?php if ( apply_filters( 'rg_paywalls_enabled', true ) ) : ?>
+				<?php if ( apply_filters( 'rg_paywalls_enabled', REVENUE_GENERATOR_HAS_PAYWALLS ) ) : ?>
 				<div id="rg_Paywall" class="rev-gen-card">
 					<img class="rev-gen-card__icon" alt="<?php esc_attr_e( 'Create Paywall icon', 'revenue-generator' ); ?>" src="<?php echo esc_url( $welcome_paywall_icon ); ?>">
 					<h5 class="rev-gen-card__title"><?php esc_html_e( 'Create Paywall', 'revenue-generator' ); ?></h5>


### PR DESCRIPTION
This PR addresses [CT-980](https://laterpay.atlassian.net/browse/CT-980).

- It adds conditions when initializing code for contributions and paywalls to allow for disabling each part individually.

- It utilizes WordPress filter hooks to enable this. Two filters are added:
  - `rg_contributions_enabled` - when set to `false`, Contributions admin screens and all related shortcodes will be disabled.
  - `rg_paywalls_enabled` - when set to `false`, Paywalls admin screens and Connector script on frontend will be disabled. Paywalls will not display and all content will become unlocked.

- The example use case is adding the following snippet to a theme or a plugin to disable contributions related code:
   - `add_filter( 'rg_contributions_enabled', '__return_false' );`

---

### Resources

- [WordPress docs on add_filter](https://developer.wordpress.org/reference/functions/add_filter/).
- [WordPress docs on apply_filters](https://developer.wordpress.org/reference/functions/apply_filters/).